### PR TITLE
Windows `test_hash_ndarray` fix

### DIFF
--- a/tests/test_KeepThis.py
+++ b/tests/test_KeepThis.py
@@ -51,7 +51,7 @@ def test_hash_index():
 
 
 def test_hash_ndarray():
-    array = np.array([1, 2, 3, 4])
+    array = np.array([1, 2, 3, 4], np.int64)
     result_hash = KeepThis._hash_ndarray(array)
     assert isinstance(result_hash, str)
     assert result_hash == '46c4f0c1fb94a6327fafea6bb1ddf0dd4ddb09f77142e1afae176f96'


### PR DESCRIPTION
hi @puhoshville! happy hacktoberfest 🎃 

This PR is to discuss changes for #15.

I've had a look into the issue, and it seems to be that on Windows the default integer type for a numpy array is `int32`. This is causing the mismatched hash.

### Linux
```python
>>> array = np.array([1, 2, 3, 4]) 
>>> array.dtype 
dtype('int64')
>>> array.data.tobytes() 
b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00'
```
### Windows
```python
>>> array = np.array([1, 2, 3, 4])
>>> array.dtype
dtype('int32')
>>> array.data.tobytes()
b'\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00'
```

The fix in this PR is to update the test to be explicit about what array to hash. This shows that the functionally of KeepThis is working.

---

However, it still leaves a potential 'incompatibility' between Windows and Linux/Mac users. I'm not sure what the right approach should be here?
- Call this out in the documentation.
- Automatically 'fix' `int32` arrays for Windows users. What if they actually wanted an `int32` array?
- Hash numpy arrays in a different way. I can't see anything (apart from `.tolist()`) that produces the same value between an `array<int32>` and an `array<int64>`.